### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(*paths):
         return f.read()
 
 v = '0.1.0'
-print "Setting up sympa"
+print ("Setting up sympa")
 
 setup(
   name = 'sympa',


### PR DESCRIPTION
fix compatibility, python3.x:
 print "Setting up sympa"
                        ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Setting up sympa")?